### PR TITLE
Edit to Nested Elements section

### DIFF
--- a/_episodes/02-csssel.md
+++ b/_episodes/02-csssel.md
@@ -386,7 +386,7 @@ Using this syntax, CSS selectors allow us to specify the exact _path_ to a set o
 If we want to select all the `blockquote` elements visible on this page, we can write:
 
 ~~~
-document.querySelectorAll('html > body > div > blockquote')
+document.querySelectorAll('html > body > div > article > blockquote')
 ~~~
 {: .source}
 


### PR DESCRIPTION
When following lesson on a mac, 

~~~
document.querySelectorAll('html > body > div > blockquote') 
~~~
did not yield intended result; instead, needed 
~~~
document.querySelectorAll('html > body > div > article > blockquote')
~~~

Please delete the text below before submitting your contribution. 

---

Thanks for contributing! If this contribution is for instructor training, please send an email to checkout@carpentries.org with a link to this contribution so we can record your progress. You’ve completed your contribution step for instructor checkout just by submitting this contribution.  

Please keep in mind that lesson maintainers are volunteers and it may be some time before they can respond to your contribution. Although not all contributions can be incorporated into the lesson materials, we appreciate your time and effort to improve the curriculum.  If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, please contact Kate Hertweck (k8hertweck@gmail.com).  

---
